### PR TITLE
Fixed python package issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "numba>=0.60.0",
     "onnxruntime>=1.20.1",
     "colorlog>=6.9.0",
     "espeakng-loader>=0.2.1",


### PR DESCRIPTION
There was a uv install issue with the packages below $ uv pip install . 
```bash                                                               
Resolved 62 packages in 34ms
   Built kokoro-onnx @ file:///Users/user/kokoro-onnx                                                                                                                    error: Failed to prepare distributions
  Caused by: Failed to fetch wheel: llvmlite==0.36.0
  Caused by: Build backend failed to determine requirements with `build_wheel()` (exit status: 1)

[stderr]
Traceback (most recent call last):
  File "<string>", line 14, in <module>
  File "/Users/user/.cache/uv/builds-v0/.tmp7v8OiV/lib/python3.12/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.cache/uv/builds-v0/.tmp7v8OiV/lib/python3.12/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
    self.run_setup()
  File "/Users/user/.cache/uv/builds-v0/.tmp7v8OiV/lib/python3.12/site-packages/setuptools/build_meta.py", line 522, in run_setup
    super().run_setup(setup_script=setup_script)
  File "/Users/user/.cache/uv/builds-v0/.tmp7v8OiV/lib/python3.12/site-packages/setuptools/build_meta.py", line 320, in run_setup
    exec(code, locals())
  File "<string>", line 55, in <module>
  File "<string>", line 52, in _guard_py_ver
RuntimeError: Cannot install on Python version 3.12.7; only versions >=3.6,<3.10 are supported.
```

Fixed the issue by adding numba dependency