### PR TITLE
fixed kokoro-onnx file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ uv add kokoro-onnx soundfile
 ```
 
 4. Paste the contents of [`examples/save.py`](https://github.com/thewh1teagle/kokoro-onnx/blob/main/examples/save.py) in `hello.py`
-5. Download the files [`kokoro-v1.0.onnx`](https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files/kokoro-v1.0.onnx), and [`voices-v1.0.bin`](https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin) and place them in the same directory.
+5. Download the files [`kokoro-v1.0.onnx`](https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx), and [`voices-v1.0.bin`](https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin) and place them in the same directory.
 6. Run
 
 ```console


### PR DESCRIPTION
I have found the file path in the readme file to be outdated (it no longer existed), so I have updated it with the correct path which I have found in /examples/save.py

## Checklist

- [x] Discussed idea or confident it's critical (See Contribute.md).
- [x] One feature/bug per PR (unless minor/related).
- [x] PR is from a **feature branch**, not `main`.
- [x] I ran at least one example to ensure the code works.
- [x] Checked linting/formatting (`uv run ruff format && uv run ruff check`).

---

## Description

<!-- Short description of the feature/bug this PR resolve; Optional: Closes #123 -->
