### PR TITLE
Fix CUDA provider detection and force GPU allocation

### DIFF
--- a/examples/with_cuda.py
+++ b/examples/with_cuda.py
@@ -22,10 +22,14 @@ Run with uv (if you cloned the repo):
 import soundfile as sf
 from kokoro_onnx import Kokoro
 import onnxruntime as ort
+import os 
 
-privders = ort.get_available_providers()
-print("Available providers:", privders)  # Make sure CUDAExecutionProvider is listed
-print(f'Is CUDA available: {"CUDAExecutionProvider" in privders}')
+
+providers = ort.get_available_providers()  # List available providers
+is_cuda = "CUDAExecutionProvider" in providers  # True if CUDA is among them
+print("Available providers:", providers)  # Show all providers
+print(f"Is CUDA available: {is_cuda}")  # Indicate if CUDA is available
+os.environ["ONNX_PROVIDER"] = "CUDAExecutionProvider" if is_cuda else "CPUExecutionProvider" # In some envs you may need to force the Cuda provider for allocate the model on GPU
 
 kokoro = Kokoro("kokoro-v1.0.onnx", "voices-v1.0.bin")
 samples, sample_rate = kokoro.create(


### PR DESCRIPTION
## Description
In some environments ONNXRuntime prints “True” for CUDA availability but still allocates the model on CPU by default.  
This PR forces the use of `CUDAExecutionProvider` when available, falling back to `CPUExecutionProvider` otherwise.

### Changes
- Correct typo in variable name (`providers` instead of `privders`).
- Properly detect `CUDAExecutionProvider` in `ort.get_available_providers()`.
- Set `ONNX_PROVIDER` env var via a one-line ternary.
- Add fallback to CPU when CUDA isn’t present.

## Checklist
- [x] Discussed idea or confident it's critical (see CONTRIBUTING.md)  
- [x] One feature/bug per PR  
- [x] PR from a feature branch, not `main`  
- [x] Tested code manually  
- [x] Linters/formatters pass (`ruff format && ruff check`)
